### PR TITLE
Add Linux Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Prerequisites
+**/*.d
+
+# Object files
+**/*.o
+**/*.ko
+**/*.obj
+**/*.elf
+
+# Linker output
+**/*.ilk
+**/*.map
+**/*.exp
+
+# Precompiled Headers
+**/*.gch
+**/*.pch
+
+# Libraries
+**/*.lib
+**/*.a
+**/*.la
+**/*.lo
+
+# Shared objects (inc. Windows DLLs)
+**/*.dll
+**/*.so
+**/*.so.*
+**/*.dylib
+
+# Executables
+**/*.exe
+**/*.out
+**/*.app
+**/*.i*86
+**/*.x86_64
+**/*.hex
+
+# Debug files
+**/*.dSYM/
+**/*.su
+**/*.idb
+**/*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+build/
+.vscode/
+.gdb_history

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,8 @@ jobs:
       - run: make test
       - run: sudo apt install valgrind -y
       - run: make SANITIZER_FLAGS=-fno-omit-frame-pointer valgrind
+  docker_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make docker_build docker_test_and_format

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,5 @@ RUN apt update && \
     apt install valgrind -y
 
 WORKDIR /usr/cairo-vm_in_C
-COPY . .
 
 CMD bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:latest
+
+RUN apt update && \
+    apt install valgrind -y
+
+WORKDIR /usr/cairo-vm_in_C
+COPY . .
+
+CMD bash

--- a/Makefile
+++ b/Makefile
@@ -100,4 +100,4 @@ docker_build:
 	docker build . -t cairo-vm_in_c
 
 docker_run:
-	docker run --rm -it -v $(pwd):/usr/cairo-vm_in_C cairo-vm_in_c
+	docker run --rm -it -v `pwd`:/usr/cairo-vm_in_C cairo-vm_in_c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos docker_build docker_run
+.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos docker_build docker_run docker_test_and_format docker_clean
 
 TARGET=cairo_vm
 TEST_TARGET=cairo_vm_test
@@ -101,3 +101,13 @@ docker_build:
 
 docker_run:
 	docker run --rm -it -v `pwd`:/usr/cairo-vm_in_C cairo-vm_in_c
+
+docker_test_and_format:
+	docker create --name test -t -v `pwd`:/usr/cairo-vm_in_C cairo-vm_in_c
+	docker start test
+	docker exec -t test bash -c "make && make test && make SANITIZER_FLAGS=-fno-omit-frame-pointer valgrind"
+	docker stop test
+	docker rm test
+
+docker_clean:
+	docker rmi cairo-vm_in_c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos
+.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos docker_build_arm docker_run
 
 TARGET=cairo_vm
 TEST_TARGET=cairo_vm_test
@@ -9,7 +9,7 @@ SANITIZER_FLAGS=-fsanitize=address -fno-omit-frame-pointer
 CFLAGS=-std=c11 -Wall -Wextra -Wimplicit-fallthrough -Werror -pedantic -g -O0
 CXX_FLAGS=-std=c++14 -Wall -Wextra -Wimplicit-fallthrough -Werror -pedantic -g -O0
 CFLAGS_TEST=-I./src
-LN_FLAGS=-L./lambdaworks/lib/lambdaworks/target/release/ -Bstatic -llambdaworks
+LN_FLAGS=-L./lambdaworks/lib/lambdaworks/target/release/ -Bstatic -llambdaworks -ldl -lpthread -lm
 
 BUILD_DIR=./build
 SRC_DIR=./src
@@ -95,3 +95,9 @@ valgrind: clean compile_rust $(TEST_TARGET)
 
 compile_rust: 
 	cd lambdaworks/lib/lambdaworks && cargo build --release
+
+docker_build_arm:
+	docker build . -t cairo-vm_in_c --platform linux/arm64/v8
+
+docker_run:
+	docker run --rm -it -v $(pwd):/usr/cairo-vm_in_C cairo-vm_in_c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos docker_build_arm docker_run
+.PHONY: clean fmt check_fmt valgrind compile_rust deps_macos docker_build docker_run
 
 TARGET=cairo_vm
 TEST_TARGET=cairo_vm_test
@@ -96,8 +96,8 @@ valgrind: clean compile_rust $(TEST_TARGET)
 compile_rust: 
 	cd lambdaworks/lib/lambdaworks && cargo build --release
 
-docker_build_arm:
-	docker build . -t cairo-vm_in_c --platform linux/arm64/v8
+docker_build:
+	docker build . -t cairo-vm_in_c
 
 docker_run:
 	docker run --rm -it -v $(pwd):/usr/cairo-vm_in_C cairo-vm_in_c

--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ To remove all compilation objects:
 make clean
 ```
 
+### Valgrind/Asan on MacOS
+
+To run `valgrind` on MacOS, first run:
+
+```
+make docker_build
+```
+
+This will build a Linux Docker image with all the dependencies needed to build the vm and run `valgrind`. Then run:
+
+```
+make docker_run
+```
+
+This will run a new container from the built image and will execute bash by using the repo root as the working directory.
+
+Finally, run:
+
+```
+make SANITIZER_FLAGS=-fno-omit-frame-pointer valgrind
+```
+
 ## Tests
 
 Tests are located in the `test` directory. To run them:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a work in progress implementation of the [Cairo VM](https://github.com/l
 - A working C compiler with `C11` support.
 - `clang-format` installed in the system.
 - [Rust](https://www.rust-lang.org/tools/install)
+- Docker (for valgrind on MacOS)
 
 ## Local development
 


### PR DESCRIPTION
- Add make commands to build image and run container.
- Add linker flags necessary to make it work inside the container.

It was tested on an Apple M1 by running `make`, `make test` and `make SANITIZER_FLAGS=-fno-omit-frame-pointer valgrind` inside the container. The image size is 1.79 GB.