### PR TITLE
Fix docker test command name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: make docker_build docker_test_and_format
+      - run: make docker_build docker_test_and_valgrind

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ docker_build:
 docker_run:
 	docker run --rm -it -v `pwd`:/usr/cairo-vm_in_C cairo-vm_in_c
 
-docker_test_and_format:
+docker_test_and_valgrind:
 	docker create --name test -t -v `pwd`:/usr/cairo-vm_in_C cairo-vm_in_c
 	docker start test
 	docker exec -t test bash -c "make clean && make docker_build_collections_lib && make test && make SANITIZER_FLAGS=-fno-omit-frame-pointer docker_valgrind"


### PR DESCRIPTION
In Docker, we don't call the format command, so the command to run in the CI shouldn't be called `docker_test_and_format`. 